### PR TITLE
Fix version injection

### DIFF
--- a/v1_bsp_ros1/setup_pc.sh
+++ b/v1_bsp_ros1/setup_pc.sh
@@ -28,7 +28,7 @@ git clone https://github.com/mangdangroboticsclub/mini_pupper_bsp.git
 git clone https://github.com/Tiryoh/ros_setup_scripts_ubuntu.git
 sudo apt-get update
 sudo apt-get -y install python3 python3-pip python-is-python3 python3-venv python3-virtualenv
-sudo pip install -e ~/mini_pupper_bsp/mock_api
+sudo PBR_VERSION=$(cd ~/mini_pupper_bsp; ./get-version.sh) pip install ~/mini_pupper_bsp/mock_api
 ~/ros_setup_scripts_ubuntu/ros-noetic-desktop-main.sh
 source /opt/ros/noetic/setup.bash
 source /usr/lib/python3/dist-packages/catkin_tools/verbs/catkin_shell_verbs.bash

--- a/v1_bsp_ros1/setup_testing.sh
+++ b/v1_bsp_ros1/setup_testing.sh
@@ -28,7 +28,7 @@ git clone https://github.com/mangdangroboticsclub/mini_pupper_bsp.git
 git clone https://github.com/Tiryoh/ros_setup_scripts_ubuntu.git
 sudo apt-get update
 sudo apt-get -y install python3 python3-pip python-is-python3 python3-venv python3-virtualenv
-sudo pip install -e ~/mini_pupper_bsp/mock_api
+sudo PBR_VERSION=$(cd ~/mini_pupper_bsp; ./get-version.sh) pip install ~/mini_pupper_bsp/mock_api
 ~/ros_setup_scripts_ubuntu/ros-noetic-ros-base-main.sh
 source /opt/ros/noetic/setup.bash
 source /usr/lib/python3/dist-packages/catkin_tools/verbs/catkin_shell_verbs.bash

--- a/v1_bsp_ros2/setup_pc.sh
+++ b/v1_bsp_ros2/setup_pc.sh
@@ -28,7 +28,7 @@ git clone https://github.com/mangdangroboticsclub/mini_pupper_bsp.git
 git clone https://github.com/Tiryoh/ros2_setup_scripts_ubuntu.git
 sudo apt-get update
 sudo apt-get -y install python3 python3-pip python-is-python3 python3-venv python3-virtualenv
-sudo pip install -e ~/mini_pupper_bsp/mock_api
+sudo PBR_VERSION=$(cd ~/mini_pupper_bsp; ./get-version.sh) pip install ~/mini_pupper_bsp/mock_api
 ~/ros2_setup_scripts_ubuntu/ros2-humble-desktop-main.sh
 source /opt/ros/humble/setup.bash
 

--- a/v1_bsp_ros2/setup_testing.sh
+++ b/v1_bsp_ros2/setup_testing.sh
@@ -41,7 +41,7 @@ cd ~
 git clone https://github.com/mangdangroboticsclub/mini_pupper_bsp.git
 sudo apt-get update
 sudo apt-get -y install python3 python3-pip python-is-python3 python3-venv python3-virtualenv
-sudo pip install -e ~/mini_pupper_bsp/mock_api
+sudo PBR_VERSION=$(cd ~/mini_pupper_bsp; ./get-version.sh) pip install ~/mini_pupper_bsp/mock_api
 
 git clone https://github.com/Tiryoh/ros2_setup_scripts_ubuntu.git
 ~/ros2_setup_scripts_ubuntu/ros2-humble-ros-base-main.sh

--- a/v1_bsp_stanford_web_controller/setup_testing.sh
+++ b/v1_bsp_stanford_web_controller/setup_testing.sh
@@ -35,7 +35,7 @@ git clone https://github.com/mangdangroboticsclub/StanfordQuadruped.git
 git clone https://github.com/mangdangroboticsclub/mini_pupper_web_controller.git
 sudo apt-get update
 sudo apt-get -y install python3 python3-pip python-is-python3 python3-venv python3-virtualenv
-sudo pip install -e ~/mini_pupper_bsp/mock_api
+sudo PBR_VERSION=$(cd ~/mini_pupper_bsp; ./get-version.sh) pip install ~/mini_pupper_bsp/mock_api
 
 cd StanfordQuadruped
 ./install.sh

--- a/v1_ros1_jupyter/setup_testing.sh
+++ b/v1_ros1_jupyter/setup_testing.sh
@@ -42,7 +42,7 @@ done
 [ -d "./ros_setup_scripts_ubuntu" ] || git clone https://github.com/Tiryoh/ros_setup_scripts_ubuntu.git
 sudo apt-get update
 sudo apt-get -y install python3 python3-pip python-is-python3 python3-venv python3-virtualenv
-sudo pip install -e ~/mini_pupper_bsp/mock_api
+sudo PBR_VERSION=$(cd ~/mini_pupper_bsp; ./get-version.sh) pip install ~/mini_pupper_bsp/mock_api
 ~/ros_setup_scripts_ubuntu/ros-noetic-ros-base-main.sh
 sudo apt install -y ros-noetic-rosbridge-server ros-noetic-tf2-web-republisher
 sudo apt install -y ros-noetic-depthai-bridge ros-noetic-depthai-examples

--- a/v2_bsp_ros1/setup_pc.sh
+++ b/v2_bsp_ros1/setup_pc.sh
@@ -28,7 +28,7 @@ git clone https://github.com/mangdangroboticsclub/mini_pupper_bsp.git
 git clone https://github.com/Tiryoh/ros_setup_scripts_ubuntu.git
 sudo apt-get update
 sudo apt-get -y install python3 python3-pip python-is-python3 python3-venv python3-virtualenv
-sudo pip install -e ~/mini_pupper_bsp/mock_api
+sudo PBR_VERSION=$(cd ~/mini_pupper_bsp; ./get-version.sh) pip install ~/mini_pupper_bsp/mock_api
 ~/ros_setup_scripts_ubuntu/ros-noetic-desktop-main.sh
 source /opt/ros/noetic/setup.bash
 source /usr/lib/python3/dist-packages/catkin_tools/verbs/catkin_shell_verbs.bash

--- a/v2_bsp_ros1/setup_testing.sh
+++ b/v2_bsp_ros1/setup_testing.sh
@@ -28,7 +28,7 @@ git clone https://github.com/mangdangroboticsclub/mini_pupper_bsp.git
 git clone https://github.com/Tiryoh/ros_setup_scripts_ubuntu.git
 sudo apt-get update
 sudo apt-get -y install python3 python3-pip python-is-python3 python3-venv python3-virtualenv
-sudo pip install -e ~/mini_pupper_bsp/mock_api
+sudo PBR_VERSION=$(cd ~/mini_pupper_bsp; ./get-version.sh) pip install ~/mini_pupper_bsp/mock_api
 ~/ros_setup_scripts_ubuntu/ros-noetic-ros-base-main.sh
 source /opt/ros/noetic/setup.bash
 source /usr/lib/python3/dist-packages/catkin_tools/verbs/catkin_shell_verbs.bash

--- a/v2_bsp_ros2/setup.sh
+++ b/v2_bsp_ros2/setup.sh
@@ -43,7 +43,7 @@ sudo apt-get update
 sudo apt-get -y install python3 python3-pip python-is-python3 python3-venv python3-virtualenv
 ./mini_pupper_bsp/install.sh
 
-# sudo pip install -e ~/mini_pupper_bsp/Python_Module
+# sudo PBR_VERSION=$(cd ~/mini_pupper_bsp; ./get-version.sh) pip install ~/mini_pupper_bsp/Python_Module
 
 git clone https://github.com/Tiryoh/ros2_setup_scripts_ubuntu.git
 ~/ros2_setup_scripts_ubuntu/ros2-humble-ros-base-main.sh

--- a/v2_bsp_ros2/setup_pc.sh
+++ b/v2_bsp_ros2/setup_pc.sh
@@ -28,7 +28,7 @@ git clone https://github.com/mangdangroboticsclub/mini_pupper_bsp.git
 git clone https://github.com/Tiryoh/ros2_setup_scripts_ubuntu.git
 sudo apt-get update
 sudo apt-get -y install python3 python3-pip python-is-python3 python3-venv python3-virtualenv
-sudo pip install -e ~/mini_pupper_bsp/mock_api
+sudo PBR_VERSION=$(cd ~/mini_pupper_bsp; ./get-version.sh) pip install ~/mini_pupper_bsp/mock_api
 ~/ros2_setup_scripts_ubuntu/ros2-humble-desktop-main.sh
 source /opt/ros/humble/setup.bash
 

--- a/v2_bsp_stanford_web_controller/setup_testing.sh
+++ b/v2_bsp_stanford_web_controller/setup_testing.sh
@@ -35,7 +35,7 @@ git clone https://github.com/mangdangroboticsclub/StanfordQuadruped.git
 git clone https://github.com/mangdangroboticsclub/mini_pupper_web_controller.git
 sudo apt-get update
 sudo apt-get -y install python3 python3-pip python-is-python3 python3-venv python3-virtualenv
-sudo pip install -e ~/mini_pupper_bsp/mock_api
+sudo PBR_VERSION=$(cd ~/mini_pupper_bsp; ./get-version.sh) pip install ~/mini_pupper_bsp/mock_api
 
 cd StanfordQuadruped
 ./install.sh


### PR DESCRIPTION
We generate a version string when we install the mock_api during testing in virtual environments
The version string will be generated by install.sh when we install mini_pupper_bsp