### PR TITLE
fixing issue 7

### DIFF
--- a/v2_bsp_ros1/setup_pc.sh
+++ b/v2_bsp_ros1/setup_pc.sh
@@ -24,7 +24,7 @@ then
 fi
 
 cd ~
-git clone https://github.com/mangdangroboticsclub/mini_pupper_bsp.git
+git clone https://github.com/mangdangroboticsclub/mini_pupper_2_bsp.git mini_pupper_bsp
 git clone https://github.com/Tiryoh/ros_setup_scripts_ubuntu.git
 sudo apt-get update
 sudo apt-get -y install python3 python3-pip python-is-python3 python3-venv python3-virtualenv

--- a/v2_bsp_ros1/setup_testing.sh
+++ b/v2_bsp_ros1/setup_testing.sh
@@ -24,7 +24,7 @@ then
 fi
 
 cd ~
-git clone https://github.com/mangdangroboticsclub/mini_pupper_bsp.git
+git clone https://github.com/mangdangroboticsclub/mini_pupper_2_bsp.git mini_pupper_bsp
 git clone https://github.com/Tiryoh/ros_setup_scripts_ubuntu.git
 sudo apt-get update
 sudo apt-get -y install python3 python3-pip python-is-python3 python3-venv python3-virtualenv

--- a/v2_bsp_ros2/setup.sh
+++ b/v2_bsp_ros2/setup.sh
@@ -38,7 +38,7 @@ tmp=$(ps aux | grep unattended-upgrade | grep -v unattended-upgrade-shutdown | g
 done
 
 cd ~
-git clone https://github.com/mangdangroboticsclub/mini_pupper_bsp.git
+git clone https://github.com/mangdangroboticsclub/mini_pupper_2_bsp.git mini_pupper_bsp
 sudo apt-get update
 sudo apt-get -y install python3 python3-pip python-is-python3 python3-venv python3-virtualenv
 ./mini_pupper_bsp/install.sh

--- a/v2_bsp_ros2/setup_pc.sh
+++ b/v2_bsp_ros2/setup_pc.sh
@@ -24,7 +24,7 @@ then
 fi
 
 cd ~
-git clone https://github.com/mangdangroboticsclub/mini_pupper_bsp.git
+git clone https://github.com/mangdangroboticsclub/mini_pupper_2_bsp.git mini_pupper_bsp
 git clone https://github.com/Tiryoh/ros2_setup_scripts_ubuntu.git
 sudo apt-get update
 sudo apt-get -y install python3 python3-pip python-is-python3 python3-venv python3-virtualenv


### PR DESCRIPTION
## Proposed change(s)

Addressing https://github.com/mangdangroboticsclub/mini_pupper/issues/7

But ROS1 should be retired and ROS2 is not ready yet. Also this includes now the correct mini_pupper_2_bsp the underlaying issue is not resolved

### Useful links (GitHub issues, forum threads, etc.)

Provide any relevant links here.

### Types of change(s)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which refactor the code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update only
- [ ] Other (please describe)

## Testing and Verification

Please describe the tests that you ran to verify your changes. Please also provide instructions and ROS packages as appropriate so we can reproduce the test environment.

1. 1st command
2. 2nd command
3. ...

## Test Configuration

__Mini Pupper Version__  
[e.g. Simulator, Mini Pupper, Mini Pupper 2, Mini Pupper 2 Pro]

__Raspberry Pi OS + ROS version__  
[e.g. Ubuntu 22.04, ROS 2 Humble]

__PC OS + ROS version__  
[e.g. Ubuntu 22.04, ROS 2 Humble]

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/mangdangroboticsclub/mini_pupper/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.


## Other comments

<!-- Please write here if you have any other comments. -->
<!-- Also, if you have screenshots or videos, please share them here. -->
