### PR TITLE
Remove ROS-specific descriptions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -36,7 +36,6 @@ body:
     label: Version
     description: What version of Mini Pupper are you running?
     options:
-      - Simulator
       - Mini Pupper
       - Mini Pupper 2
       - Mini Pupper 2 Pro

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,14 @@
 ## Proposed change(s)
 
-Describe the changes made in this PR.
+<!-- Describe the changes made in this PR. -->
 
 ### Useful links (GitHub issues, forum threads, etc.)
 
-Provide any relevant links here.
+<!-- Provide any relevant links here. -->
 
 ### Types of change(s)
+
+<!-- Select one or more. -->
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
@@ -17,7 +19,7 @@ Provide any relevant links here.
 
 ## Testing and Verification
 
-Please describe the tests that you ran to verify your changes. Please also provide instructions and ROS packages as appropriate so we can reproduce the test environment.
+<!-- Please describe the tests that you ran to verify your changes. Please also provide instructions as appropriate so we can reproduce the test environment. -->
 
 1. 1st command
 2. 2nd command
@@ -26,13 +28,13 @@ Please describe the tests that you ran to verify your changes. Please also provi
 ## Test Configuration
 
 __Mini Pupper Version__  
-[e.g. Simulator, Mini Pupper, Mini Pupper 2, Mini Pupper 2 Pro]
+<!-- [e.g. Mini Pupper, Mini Pupper 2, Mini Pupper 2 Pro] -->
 
-__Raspberry Pi OS + ROS version__  
-[e.g. Ubuntu 22.04, ROS 2 Humble]
+__Raspberry Pi OS version__  
+<!-- [e.g. Ubuntu 22.04] -->
 
-__PC OS + ROS version__  
-[e.g. Ubuntu 22.04, ROS 2 Humble]
+__PC OS version__  
+<!-- [e.g. Ubuntu 22.04] -->
 
 ## Checklist
 


### PR DESCRIPTION
## Proposed change(s)

Remove ROS-specific descriptions from GitHub Issue/Pull request template

### Useful links (GitHub issues, forum threads, etc.)

* https://github.com/mangdangroboticsclub/mini_pupper/pull/6

### Types of change(s)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which refactor the code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update only
- [x] Other (update GitHub config)



## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/mangdangroboticsclub/mini_pupper/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.


## Other comments

<!-- Please write here if you have any other comments. -->
<!-- Also, if you have screenshots or videos, please share them here. -->
